### PR TITLE
Add project badges and Apache 2.0 license

### DIFF
--- a/.github/carl/current-pr-contract.md
+++ b/.github/carl/current-pr-contract.md
@@ -1,107 +1,68 @@
-<!-- version: 1.1.0 -->
+<!-- version: 1.3.0 -->
 # Current PR Contract
 
-This contract constrains implementation scope for the active PR. Update
-it when scope is explicitly amended. If a requested action falls outside
-approved scope, stop and escalate before proceeding.
-
-Use this contract to distinguish active PR constraints, completed PR
-constraints, durable invariants, and intentional amendments. Completed
-PR constraints are historical evidence unless they are explicitly
-promoted to durable invariants.
-
 ## Goal
-Fix the 18 failing pytest tests caused by `compute_risk_for_sp()` API
-drift: restore alignment between the test suite and the current function
-signature in `oidsee_scanner.py` after commit `10c5b3e` removed the
-`has_privileged_scopes`/`has_too_many_scopes` (and related
-`has_readwrite_all_scopes`/`has_action_scopes`) boolean parameters in
-favour of deriving scope risk from `delegated_scopes_by_resource` via
-`classify_scopes()`.
+Improve the project metadata by adding a concise set of relevant Shields.io
+badges and making the repository's declared Apache 2.0 licensing explicit
+through a canonical root licence file.
 
 ## Contract status
 active
-<!-- Uncommitted in the working tree as of 2026-07-04; not yet opened as a GitHub PR. -->
 
 ## Non-goals
-- Fixing the missing `fetch_group_member_counts_batched`/
-  `group_member_count_cache` batched-group-counting feature (6 unrelated
-  failing tests) — this is a separate, larger feature gap, not test debt.
-- Fixing `tests/test_report_generator.py::test_generate_report`'s missing
-  "Apps Without Owners" metric — separate root cause in
-  `report_generator.py`.
-- Adding `jsonschema` to `requirements.txt` (documented as a follow-up,
-  not required to fix the target failures).
-- Any change to production scoring/business logic in `oidsee_scanner.py`.
-- Any broad refactor, dependency upgrade, or CI workflow addition.
-
-## Carry-forward rules
-The `scanner-signature-test-sync` invariant (added to
-`.github/carl/invariants.yml` in this same change) is a durable rule and
-carries forward beyond this PR. The specific list of 6 touched test files
-below is scoped to this PR only and is not a durable constraint.
+- Changing application code, scoring logic, schemas, tests, or dependencies.
+- Adding CI workflows or badges that imply an automated test/build status.
+- Claiming capabilities or compatibility not evidenced by the repository.
 
 ## Approved scope
-- Remove stale/obsolete keyword arguments from `compute_risk_for_sp(...)`
-  call sites in:
-  - `tests/test_appownership_risk_logic.py`
-  - `tests/test_empty_replyurls.py`
-  - `tests/test_enrichment_filtering.py`
-  - `tests/test_integration_e2e.py`
-  - `tests/test_new_scoring_contributors.py`
-  - `tests/test_tier_scoring.py`
-- Where a removed boolean flag was set to `True` and asserted on
-  (`test_integration_e2e.py::test_combined_scenario` expecting
-  `HAS_PRIVILEGED_SCOPES`), substitute an equivalent
-  `delegated_scopes_by_resource` entry so the test still exercises the
-  intended behaviour through the current API.
+- Update the badge block near the top of `README.md`.
+- Remove or correct an existing badge when its target is missing or stale.
+- Add the canonical Apache License 2.0 text as `LICENSE`.
+- Restore the Apache 2.0 badge and link it to `LICENSE`.
+- Keep this contract aligned with the metadata-only implementation scope.
 
 ## Intentional amendments
-None. This PR does not amend any existing invariant or trust boundary;
-it adds new repo-specific invariants and durable memory (see cARL/docs
-update decision in final response).
+This contract supersedes the completed `compute_risk_for_sp()` test-signature
+sync contract merged in PR #89. No durable invariant or trust boundary is
+amended. The user explicitly expanded scope to add the Apache 2.0 licence
+already declared in `README.md`.
 
 ## Forbidden scope
-- No changes to `oidsee_scanner.py` or any other production file.
-- No changes to test files outside the 6 listed above.
-- No dependency additions or version bumps.
-- No CI workflow creation.
+- No changes outside `README.md`, `LICENSE`, and this contract.
+- No dependency, application, schema, test, CI, or release changes.
 
 ## Architectural constraints
-Scope-risk detection must remain sourced from `delegated_scopes_by_resource`
-processed through `classify_scopes()`; tests must exercise this real path
-rather than reintroducing removed boolean flags.
+- Badges must use Shields.io image URLs.
+- Static version claims must match the current repository manifests and code.
+- Badge links must point to relevant repository documentation or authoritative
+  project pages.
+- `LICENSE` must reproduce the canonical Apache License 2.0 text.
 
 ## Security constraints
-No authentication, authorization, validation, or secret-handling behaviour
-is affected by this PR.
+- Do not add secrets, tokens, private endpoints, or badges requiring embedded
+  credentials.
+- Describe Microsoft Graph access as read-only, consistent with project
+  invariants.
 
 ## Files expected to change
-- `tests/test_appownership_risk_logic.py`
-- `tests/test_empty_replyurls.py`
-- `tests/test_enrichment_filtering.py`
-- `tests/test_integration_e2e.py`
-- `tests/test_new_scoring_contributors.py`
-- `tests/test_tier_scoring.py`
+- `README.md`
+- `LICENSE`
+- `.github/carl/current-pr-contract.md`
 
 ## Tests / validation
-- `python -m pytest tests/ -q` — result: 25 failed / 203 passed before the
-  fix; 7 failed / 221 passed after (the 7 remaining failures are the
-  explicitly out-of-scope issues listed under Non-goals).
-- Targeted reruns of each of the 6 touched files individually — all green.
+- Inspect the rendered Markdown structure and badge targets.
+- Compare the licence heading and sections with the canonical Apache source.
+- Verify version/capability claims against repository files.
+- Run `git diff --check`.
 
 ## Stop conditions
-Stop and escalate if fixing the target failures would require modifying
-`oidsee_scanner.py` (it should not — production code is already correct
-per the intentional `10c5b3e` refactor).
+Stop if an appropriate badge would require a secret, external account
+configuration, a new workflow, or an unsupported compatibility claim.
 
 ## Escalation triggers
-If any of the 7 remaining out-of-scope failures turn out to share the
-same root cause as the in-scope fix, pause and confirm with the user
-before expanding scope.
+Ask before expanding the change beyond project licensing and the README badge
+block.
 
 ## Context reset notes
-Close this contract once the test-file changes are committed/merged (or
-explicitly abandoned). At that point, promote no additional constraints
-beyond the `scanner-signature-test-sync` invariant already recorded in
-`.github/carl/invariants.yml`.
+Close or supersede this contract when the README badge change is committed,
+merged, or abandoned. No new durable invariant is expected.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@
 # OID-See
 
 [![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)](https://github.com/OID-See/OID-See)
+[![Status](https://img.shields.io/badge/status-stable-brightgreen.svg)](RELEASE_NOTES_v1.1.1.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-stable-brightgreen.svg)](RELEASE_NOTES_v1.0.md)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/)
+[![React](https://img.shields.io/badge/React-19-61DAFB.svg?logo=react&logoColor=black)](https://react.dev/)
+[![Microsoft Graph](https://img.shields.io/badge/Microsoft%20Graph-read--only-00A4EF.svg?logo=microsoft&logoColor=white)](docs/scanner.md#security-considerations)
+[![SARIF](https://img.shields.io/badge/SARIF-2.1.0-5C2D91.svg)](docs/scanner.md#sarif-210-output)
+[![BloodHound](https://img.shields.io/badge/BloodHound-OpenGraph-CC0000.svg)](RELEASE_NOTES_v1.1.1.md)
 
 **Visualize and assess security risks in your Microsoft Entra ID tenant's third-party and multi-tenant applications.**
 


### PR DESCRIPTION
## Summary

- add concise Shields.io badges for the project version, stability, Python, React, Microsoft Graph, SARIF, and BloodHound OpenGraph
- add the canonical Apache License 2.0 text at the repository root
- restore the Apache 2.0 README badge and link it to the new licence file
- supersede the completed test-fix cARL contract with the scoped project-metadata contract

## Why

The README declared Apache 2.0 licensing, but the repository did not contain a `LICENSE` file and its existing licence badge target was broken. The project also lacked concise metadata for its primary technologies and supported security-export integrations.

## Impact

This is a documentation and repository-metadata change only. It does not change scanner behaviour, scoring, schemas, dependencies, tests, CI, or tenant access.

## Validation

- `git diff --check`
- verified all nine Apache License 2.0 sections and the standard appendix are present
- verified the licence badge resolves to `LICENSE`
- verified every badge image uses Shields.io
- application tests not run because no application code changed
